### PR TITLE
Configure packages to install in a variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,8 @@ htpasswd: []
 htpasswd_path: /etc/htpasswd
 # default crypt [apr_md5_crypt | des_crypt | ldap_sha1 | plaintext]
 htpasswd_crypt: apr_md5_crypt
+
+# List of package to install, python-passlib is a pre-requisite for htpasswd ansible module
+htpasswd_packages:
+  - python-passlib
+  - apache2-utils

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,9 +4,7 @@
   apt:
     pkg: "{{ item }}"
     state: present
-  with_items:
-    - python-passlib
-    - apache2-utils
+  with_items: htpasswd_packages
 
 - name: Creating htpasswd folder
   file:


### PR DESCRIPTION
The package to install are now configured in a variable allowing to override it's definition.
For example on my NGINX server I don't want to install apache2-utils packages.
