### PR TITLE
Not create base path if variable htpasswd_path is not defined or empty

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,3 +15,4 @@
     owner: root
     group: root
     mode: "0755"
+  when: not((htpasswd_path is undefined) or (htpasswd_path is none) or (htpasswd_path|trim == ''))


### PR DESCRIPTION
Let the possibility to not define htpasswd_path variable and not create the base path directory
