### PR TITLE
Added no_log attribute to secure user credentials from logging

### DIFF
--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Adding htpasswd files
+  no_log: True
   htpasswd:
     name: "{{ item.1.name }}"
     path: "{{ item.0.path | default(htpasswd_path) ~ '/' ~ item.0.name }}"


### PR DESCRIPTION
Hello!

Thanks a lot for this ansible role! I've been using it a lot. 
One thing that I'm worrying about while using the role is that user's credentials a logged into stout while running the playbook. 

Would you consider to merge my pull request with the no_log flag to the "Adding htpasswd files" task? 
